### PR TITLE
fix: use history api instead of gatsby navigate to modify query parameter

### DIFF
--- a/app/gatsby-config.js
+++ b/app/gatsby-config.js
@@ -1,36 +1,35 @@
 module.exports = {
   siteMetadata: {
-    siteUrl: "https://www.yourdomain.tld",
-    title: "Behavior Data Pipeline Demo App",
+    siteUrl: 'https://www.yourdomain.tld',
+    title: 'Behavior Data Pipeline Demo App',
   },
   plugins: [
-    "gatsby-plugin-styled-components",
-    "gatsby-plugin-image",
-    "gatsby-plugin-react-helmet",
-    "gatsby-plugin-sitemap",
-    "gatsby-plugin-netlify",
+    'gatsby-plugin-styled-components',
+    'gatsby-plugin-image',
+    'gatsby-plugin-react-helmet',
+    'gatsby-plugin-sitemap',
+    'gatsby-plugin-netlify',
     {
-      resolve: "gatsby-plugin-manifest",
+      resolve: 'gatsby-plugin-manifest',
       options: {
-        icon: "assets/images/icon.png",
+        icon: 'assets/images/icon.png',
       },
     },
-    "gatsby-plugin-sharp",
-    "gatsby-transformer-sharp",
+    'gatsby-plugin-sharp',
+    'gatsby-transformer-sharp',
     {
-      resolve: "gatsby-source-filesystem",
+      resolve: 'gatsby-source-filesystem',
       options: {
-        name: "images",
-        path: "./assets/images/",
+        name: 'images',
+        path: './assets/images/',
       },
-      __key: "images",
+      __key: 'images',
     },
-
     {
-      resolve: "gatsby-plugin-google-tagmanager",
+      resolve: 'gatsby-plugin-google-tagmanager',
       options: {
-        id: "GTM-K9KBLVV",
-      }
-    }
+        id: 'GTM-K9KBLVV',
+      },
+    },
   ],
-};
+}

--- a/app/package.json
+++ b/app/package.json
@@ -39,7 +39,6 @@
     "gatsby-plugin-styled-components": "^4.10.0",
     "gatsby-source-filesystem": "^3.11.0",
     "gatsby-transformer-sharp": "^3.11.0",
-    "query-string": "^7.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",

--- a/app/src/pages/products.jsx
+++ b/app/src/pages/products.jsx
@@ -2,11 +2,9 @@ import React, { useState, useEffect } from 'react'
 import { useCart } from 'react-use-cart'
 import { RadioGroup } from '@headlessui/react'
 import classNames from 'classnames'
-// import ReviewsList from '../components/ReviewsList'
 import { products } from '../res/data'
 import { getFormattedPrice } from '../utils/getFormattedPrice'
 import { Drawer, DrawerHeader, DrawerBody, DrawerFooter } from '../components/Drawer'
-import { navigate } from 'gatsby'
 
 const ProductPage = ({ location }) => {
   const params = location.search ? new URLSearchParams(location.search) : null
@@ -42,7 +40,11 @@ const ProductPage = ({ location }) => {
   const toggleSizeDrawer = () => setIsSizeDrawerOpen(!isSizeDrawerOpen)
 
   useEffect(() => {
-    navigate(`/products?id=${variantId}&color=${selectedColor}&size=${selectedSize.name}`)
+    if (window.history.pushState) {
+      const newURL = new URL(window.location.href)
+      newURL.search = `?id=${variantId}&color=${selectedColor}&size=${selectedSize.name}`
+      window.history.replaceState(null, '', newURL.href)
+    }
   }, [selectedColor, selectedSize])
 
   return (
@@ -294,8 +296,6 @@ const ProductPage = ({ location }) => {
           </Drawer>
         </div>
       </div>
-
-      {/* {product.reviews ? <ReviewsList productId={product.id} reviews={product.reviews} /> : null} */}
     </>
   )
 }

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -10704,16 +10704,6 @@ query-string@^6.13.1, query-string@^6.13.8:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-query-string@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.0.1.tgz#45bd149cf586aaa582dffc7ec7a8ad97dd02f75d"
-  integrity sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"


### PR DESCRIPTION
Previously using Gatsby's navigate method to update query parameter for size &color of the product caused page reload. Switched to use history API instead (history.replaceState method)
